### PR TITLE
[Feat] : Diary Api 생성

### DIFF
--- a/src/main/java/com/capstone/Carvedream/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/auth/presentation/AuthController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Authorization", description = "인증 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/capstone/Carvedream/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/auth/presentation/AuthController.java
@@ -82,7 +82,7 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "탈퇴 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "탈퇴 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @DeleteMapping(value="/cancel")
+    @DeleteMapping
     public ResponseEntity<Message> cancel(
             @Parameter(description = "Schemas의 RefreshTokenRequest를 참고해주세요.", required = true) @Valid @RequestBody RefreshTokenReq tokenRefreshRequest
     ) {

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -1,11 +1,48 @@
 package com.capstone.Carvedream.domain.diary.application;
 
+import com.capstone.Carvedream.domain.diary.domain.Diary;
+import com.capstone.Carvedream.domain.diary.domain.repository.DiaryRepository;
+import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
+import com.capstone.Carvedream.domain.diary.dto.response.CreateDiaryRes;
+import com.capstone.Carvedream.domain.user.domain.User;
+import com.capstone.Carvedream.domain.user.domain.repository.UserRepository;
+import com.capstone.Carvedream.domain.user.exception.InvalidUserException;
+import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
+import com.capstone.Carvedream.global.payload.CommonDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class DiaryService {
+
+    private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
+
+    // 꿈 일기 생성
+    @Transactional
+    public CommonDto createDiary(UserPrincipal userPrincipal, CreateDiaryReq createDiaryReq) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
+
+        Diary diary = Diary.builder()
+                .title(createDiaryReq.getTitle())
+                .content(createDiaryReq.getContent())
+                .start_sleep(createDiaryReq.getStart_sleep())
+                .end_sleep(createDiaryReq.getEnd_sleep())
+                .emotion(createDiaryReq.getEmotion())
+                .date(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        diaryRepository.save(diary);
+
+        CreateDiaryRes createDiaryRes = new CreateDiaryRes(diary.getId());
+
+        return new CommonDto(true, createDiaryRes);
+    }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -1,0 +1,11 @@
+package com.capstone.Carvedream.domain.diary.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class DiaryService {
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -68,4 +68,19 @@ public class DiaryService {
 
         return new CommonDto(true, updateDiaryRes);
     }
+
+    // 꿈 일기 삭제
+    @Transactional
+    public CommonDto deleteDiary(UserPrincipal userPrincipal, Long id) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
+        Diary diary = diaryRepository.findById(id).orElseThrow(InvalidDiaryException::new);
+
+        if (!diary.getUser().equals(user)) {
+            throw new InvalidDiaryException();
+        }
+
+        diaryRepository.delete(diary);
+
+        return new CommonDto(true, Message.builder().message("꿈이 삭제되었습니다.").build());
+    }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -5,6 +5,7 @@ import com.capstone.Carvedream.domain.diary.domain.repository.DiaryRepository;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.response.CreateDiaryRes;
+import com.capstone.Carvedream.domain.diary.dto.response.FindDiaryRes;
 import com.capstone.Carvedream.domain.diary.dto.response.UpdateDiaryRes;
 import com.capstone.Carvedream.domain.diary.exception.InvalidDiaryException;
 import com.capstone.Carvedream.domain.user.domain.User;
@@ -82,5 +83,29 @@ public class DiaryService {
         diaryRepository.delete(diary);
 
         return new CommonDto(true, Message.builder().message("꿈이 삭제되었습니다.").build());
+    }
+
+    // id로 꿈 일기 조회
+    public CommonDto findDiary(UserPrincipal userPrincipal, Long id) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
+        Diary diary = diaryRepository.findById(id).orElseThrow(InvalidDiaryException::new);
+
+        if (!diary.getUser().equals(user)) {
+            throw new InvalidDiaryException();
+        }
+
+        FindDiaryRes findDiaryRes = FindDiaryRes.builder()
+                .id(diary.getId())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .date(diary.getDate())
+                .emotion(diary.getEmotion())
+                .image_url(diary.getImage_url())
+                .end_sleep(diary.getEnd_sleep())
+                .start_sleep(diary.getStart_sleep())
+                .interpretation(diary.getInterpretation())
+                .build();
+
+        return new CommonDto(true, findDiaryRes);
     }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -15,10 +15,13 @@ import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
 import com.capstone.Carvedream.global.payload.CommonDto;
 import com.capstone.Carvedream.global.payload.Message;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -105,6 +108,30 @@ public class DiaryService {
                 .start_sleep(diary.getStart_sleep())
                 .interpretation(diary.getInterpretation())
                 .build();
+
+        return new CommonDto(true, findDiaryRes);
+    }
+
+    // 유저의 모든 꿈 일기 조회
+    public CommonDto findAllDiary(UserPrincipal userPrincipal, Integer page) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
+
+        Page<Diary> diaryPage = diaryRepository.findAllByUser(user, PageRequest.of(page, 10));
+
+
+        List<FindDiaryRes> findDiaryRes = diaryPage.stream().map(
+                diary -> FindDiaryRes.builder()
+                    .id(diary.getId())
+                    .title(diary.getTitle())
+                    .content(diary.getContent())
+                    .date(diary.getDate())
+                    .emotion(diary.getEmotion())
+                    .image_url(diary.getImage_url())
+                    .end_sleep(diary.getEnd_sleep())
+                    .start_sleep(diary.getStart_sleep())
+                    .interpretation(diary.getInterpretation())
+                    .build()
+        ).toList();
 
         return new CommonDto(true, findDiaryRes);
     }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/application/DiaryService.java
@@ -3,18 +3,21 @@ package com.capstone.Carvedream.domain.diary.application;
 import com.capstone.Carvedream.domain.diary.domain.Diary;
 import com.capstone.Carvedream.domain.diary.domain.repository.DiaryRepository;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
+import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.response.CreateDiaryRes;
+import com.capstone.Carvedream.domain.diary.dto.response.UpdateDiaryRes;
+import com.capstone.Carvedream.domain.diary.exception.InvalidDiaryException;
 import com.capstone.Carvedream.domain.user.domain.User;
 import com.capstone.Carvedream.domain.user.domain.repository.UserRepository;
 import com.capstone.Carvedream.domain.user.exception.InvalidUserException;
 import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
 import com.capstone.Carvedream.global.payload.CommonDto;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.capstone.Carvedream.global.payload.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @RequiredArgsConstructor
 @Service
@@ -35,7 +38,7 @@ public class DiaryService {
                 .start_sleep(createDiaryReq.getStart_sleep())
                 .end_sleep(createDiaryReq.getEnd_sleep())
                 .emotion(createDiaryReq.getEmotion())
-                .date(LocalDateTime.now())
+                .date(LocalDate.now())
                 .user(user)
                 .build();
 
@@ -44,5 +47,25 @@ public class DiaryService {
         CreateDiaryRes createDiaryRes = new CreateDiaryRes(diary.getId());
 
         return new CommonDto(true, createDiaryRes);
+    }
+
+    // 꿈 일기 수정
+    @Transactional
+    public CommonDto updateDiary(UserPrincipal userPrincipal, UpdateDiaryReq updateDiaryReq) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
+        Diary diary = diaryRepository.findById(updateDiaryReq.getId()).orElseThrow(InvalidDiaryException::new);
+
+        if (!diary.getUser().equals(user)) {
+            throw new InvalidDiaryException();
+        }
+
+        diary.updateDiary(updateDiaryReq.getTitle(), updateDiaryReq.getContent(), updateDiaryReq.getDate(), updateDiaryReq.getEmotion(), updateDiaryReq.getStart_sleep(), updateDiaryReq.getEnd_sleep());
+
+        UpdateDiaryRes updateDiaryRes = UpdateDiaryRes.builder()
+                .changed(diary.getChanged())
+                .message("꿈이 성공적으로 수정되었습니다.")
+                .build();
+
+        return new CommonDto(true, updateDiaryRes);
     }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
@@ -3,6 +3,7 @@ package com.capstone.Carvedream.domain.diary.domain;
 import com.capstone.Carvedream.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,4 +43,18 @@ public class Diary {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public Diary(String title, String content, String image_url, LocalDateTime date, String interpretation, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep, Boolean changed, User user) {
+        this.title = title;
+        this.content = content;
+        this.image_url = image_url;
+        this.date = date;
+        this.interpretation = interpretation;
+        this.emotion = emotion;
+        this.start_sleep = start_sleep;
+        this.end_sleep = end_sleep;
+        this.changed = changed;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
@@ -45,7 +45,7 @@ public class Diary {
     private User user;
 
     @Builder
-    public Diary(String title, String content, String image_url, LocalDateTime date, String interpretation, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep, Boolean changed, User user) {
+    public Diary(String title, String content, String image_url, LocalDateTime date, String interpretation, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep, User user) {
         this.title = title;
         this.content = content;
         this.image_url = image_url;
@@ -54,7 +54,7 @@ public class Diary {
         this.emotion = emotion;
         this.start_sleep = start_sleep;
         this.end_sleep = end_sleep;
-        this.changed = changed;
+        this.changed = false;
         this.user = user;
     }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
@@ -1,5 +1,6 @@
 package com.capstone.Carvedream.domain.diary.domain;
 
+import com.capstone.Carvedream.domain.common.BaseEntity;
 import com.capstone.Carvedream.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ import java.time.LocalTime;
 @Getter
 @Entity
 @Table(name = "diary")
-public class Diary {
+public class Diary extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
@@ -1,0 +1,45 @@
+package com.capstone.Carvedream.domain.diary.domain;
+
+import com.capstone.Carvedream.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "diary")
+public class Diary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private String image_url;
+
+    private LocalDateTime date;
+
+    private String interpretation;
+
+    @Column(name = "emotion")
+    @Enumerated(EnumType.STRING)
+    private Emotion emotion;
+
+    private LocalTime start_sleep;
+
+    private LocalTime end_sleep;
+
+    private Boolean changed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Diary.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,7 +26,7 @@ public class Diary {
 
     private String image_url;
 
-    private LocalDateTime date;
+    private LocalDate date;
 
     private String interpretation;
 
@@ -45,7 +45,7 @@ public class Diary {
     private User user;
 
     @Builder
-    public Diary(String title, String content, String image_url, LocalDateTime date, String interpretation, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep, User user) {
+    public Diary(String title, String content, String image_url, LocalDate date, String interpretation, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep, User user) {
         this.title = title;
         this.content = content;
         this.image_url = image_url;
@@ -56,5 +56,15 @@ public class Diary {
         this.end_sleep = end_sleep;
         this.changed = false;
         this.user = user;
+    }
+
+    public void updateDiary(String title, String content, LocalDate date, Emotion emotion, LocalTime start_sleep, LocalTime end_sleep) {
+        this.title = title;
+        this.content = content;
+        this.date = date;
+        this.emotion = emotion;
+        this.start_sleep = start_sleep;
+        this.end_sleep = end_sleep;
+        this.changed = true;
     }
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/Emotion.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/Emotion.java
@@ -1,0 +1,5 @@
+package com.capstone.Carvedream.domain.diary.domain;
+
+public enum Emotion {
+    THRILL, YEARNING, FEAR, AWKWARDNESS, MYSTERY, ABSURDITY, EXCITED, JOY, ANGER
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/repository/DiaryRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.Carvedream.domain.diary.domain.repository;
+
+import com.capstone.Carvedream.domain.diary.domain.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/domain/repository/DiaryRepository.java
@@ -1,9 +1,14 @@
 package com.capstone.Carvedream.domain.diary.domain.repository;
 
 import com.capstone.Carvedream.domain.diary.domain.Diary;
+import com.capstone.Carvedream.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    Page<Diary> findAllByUser(User user, PageRequest pageRequest);
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/CreateDiaryReq.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/CreateDiaryReq.java
@@ -1,0 +1,30 @@
+package com.capstone.Carvedream.domain.diary.dto.request;
+
+import com.capstone.Carvedream.domain.diary.domain.Emotion;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalTime;
+
+@Data
+@Schema(description = "CreateDiaryRequest")
+public class CreateDiaryReq {
+
+    @Schema(description = "제목", example = "좋은 꿈")
+    private String title;
+
+    @Schema(description = "내용", example = "캡스톤 A+받는 꿈이다. 행복했다.")
+    private String content;
+
+    @Schema(description = "수면 시작 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime start_sleep;
+
+    @Schema(description = "수면 종료 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime end_sleep;
+
+    @Schema(description = "감정", example = "THRILL")
+    private Emotion emotion;
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/UpdateDiaryReq.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/UpdateDiaryReq.java
@@ -1,0 +1,37 @@
+package com.capstone.Carvedream.domain.diary.dto.request;
+
+import com.capstone.Carvedream.domain.diary.domain.Emotion;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Schema(description = "UpdateDiaryRequest")
+public class UpdateDiaryReq {
+
+    @Schema(description = "일기ID", example = "1")
+    private Long id;
+
+    @Schema(description = "제목", example = "좋은 꿈")
+    private String title;
+
+    @Schema(description = "내용", example = "캡스톤 A+받는 꿈이다. 행복했다.")
+    private String content;
+
+    @Schema(description = "수면 시작 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime start_sleep;
+
+    @Schema(description = "수면 종료 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime end_sleep;
+
+    @Schema(description = "날짜", example = "2024-04-13")
+    private LocalDate date;
+
+    @Schema(description = "감정", example = "THRILL")
+    private Emotion emotion;
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/CreateDiaryRes.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/CreateDiaryRes.java
@@ -1,0 +1,14 @@
+package com.capstone.Carvedream.domain.diary.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class CreateDiaryRes {
+    private Long id;
+
+    @Builder
+    public CreateDiaryRes(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/FindDiaryRes.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/FindDiaryRes.java
@@ -1,0 +1,56 @@
+package com.capstone.Carvedream.domain.diary.dto.response;
+
+import com.capstone.Carvedream.domain.diary.domain.Emotion;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+public class FindDiaryRes {
+
+    @Schema(description = "일기ID", example = "1")
+    private Long id;
+
+    @Schema(description = "제목", example = "좋은 꿈")
+    private String title;
+
+    @Schema(description = "내용", example = "캡스톤 A+받는 꿈이다. 행복했다.")
+    private String content;
+
+    @Schema(description = "이미지 사진", example = "https://i.namu.wiki/i/GQMqb8jtiqpCo6_US7jmWDO30KfPB2MMvbdURVub61Rs6ALKqbG-nUATj-wNk7bXXWIDjiLHJxWYkTELUgybkA.webp")
+    private String image_url;
+
+    @Schema(description = "수면 시작 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime start_sleep;
+
+    @Schema(description = "수면 종료 시간", example = "00:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime end_sleep;
+
+    @Schema(description = "날짜", example = "2024-04-13")
+    private LocalDate date;
+
+    @Schema(description = "감정", example = "THRILL")
+    private Emotion emotion;
+
+    @Schema(description = "해몽", example = "이 꿈은 탐험적인 성격을 가진 일상 생활의 변화를 예상할 수 있습니다.")
+    private String interpretation;
+
+    @Builder
+    public FindDiaryRes(Long id, String title, String content, String image_url, LocalTime start_sleep, LocalTime end_sleep, LocalDate date, Emotion emotion, String interpretation) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.image_url = image_url;
+        this.start_sleep = start_sleep;
+        this.end_sleep = end_sleep;
+        this.date = date;
+        this.emotion = emotion;
+        this.interpretation = interpretation;
+    }
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/UpdateDiaryRes.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/response/UpdateDiaryRes.java
@@ -1,0 +1,18 @@
+package com.capstone.Carvedream.domain.diary.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class UpdateDiaryRes {
+
+    private Boolean changed;
+
+    private String message;
+
+    @Builder
+    public UpdateDiaryRes(Boolean changed, String message) {
+        this.changed = changed;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/exception/InvalidDiaryException.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/exception/InvalidDiaryException.java
@@ -1,0 +1,8 @@
+package com.capstone.Carvedream.domain.diary.exception;
+
+public class InvalidDiaryException  extends RuntimeException {
+
+    public InvalidDiaryException(){
+        super("일기가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -2,11 +2,11 @@ package com.capstone.Carvedream.domain.diary.presentation;
 
 import com.capstone.Carvedream.domain.diary.application.DiaryService;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
+import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
 import com.capstone.Carvedream.global.config.security.token.CurrentUser;
 import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
 import com.capstone.Carvedream.global.payload.CommonDto;
 import com.capstone.Carvedream.global.payload.ErrorResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,10 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Diary", description = "꿈 일기 API")
 @RestController
@@ -40,8 +37,22 @@ public class DiaryController {
     public ResponseEntity<CommonDto> createDiary(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Valid @RequestBody CreateDiaryReq createDiaryReq
-    ) throws JsonProcessingException {
+    ) {
         return ResponseEntity.ok(diaryService.createDiary(userPrincipal, createDiaryReq));
+    }
+
+    //꿈 일기 수정
+    @Operation(summary = "꿈 일기 수정", description = "꿈 일기를 수정합니다. (해몽, 이미지 제외)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UpdateDiaryReq.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "수정 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PatchMapping
+    public ResponseEntity<CommonDto> updateDiary(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Valid @RequestBody UpdateDiaryReq updateDiaryReq
+            ) {
+        return ResponseEntity.ok(diaryService.updateDiary(userPrincipal, updateDiaryReq));
     }
 
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -1,16 +1,47 @@
 package com.capstone.Carvedream.domain.diary.presentation;
 
+import com.capstone.Carvedream.domain.diary.application.DiaryService;
+import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
+import com.capstone.Carvedream.global.config.security.token.CurrentUser;
+import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
+import com.capstone.Carvedream.global.payload.CommonDto;
+import com.capstone.Carvedream.global.payload.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Diary", description = "Diary API")
+@Tag(name = "Diary", description = "꿈 일기 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/diary")
 public class DiaryController {
 
+    private final DiaryService diaryService;
 
+    //꿈 일기 저장
+    @Operation(summary = "꿈 일기 저장", description = "오늘 기준 꿈 일기를 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CreateDiaryReq.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping
+    public ResponseEntity<CommonDto> createDiary(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Valid @RequestBody CreateDiaryReq createDiaryReq
+    ) throws JsonProcessingException {
+        return ResponseEntity.ok(diaryService.createDiary(userPrincipal, createDiaryReq));
+    }
 
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -87,4 +87,18 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.findDiary(userPrincipal, diaryId));
     }
 
+    //꿈 일기 조회(모두)
+    @Operation(summary = "모든 꿈 일기 조회", description = "유저에 해당하는 모든 꿈 일기를 조회합니다. (페이징은 0부터 시작)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindDiaryRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping
+    public ResponseEntity<CommonDto> findAllDiary (
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam(name = "page") Integer page
+    ) {
+        return ResponseEntity.ok(diaryService.findAllDiary(userPrincipal, page));
+    }
+
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -1,0 +1,16 @@
+package com.capstone.Carvedream.domain.diary.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Diary", description = "Diary API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/diary")
+public class DiaryController {
+
+
+
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -3,10 +3,13 @@ package com.capstone.Carvedream.domain.diary.presentation;
 import com.capstone.Carvedream.domain.diary.application.DiaryService;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
+import com.capstone.Carvedream.domain.diary.dto.response.CreateDiaryRes;
+import com.capstone.Carvedream.domain.diary.dto.response.UpdateDiaryRes;
 import com.capstone.Carvedream.global.config.security.token.CurrentUser;
 import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
 import com.capstone.Carvedream.global.payload.CommonDto;
 import com.capstone.Carvedream.global.payload.ErrorResponse;
+import com.capstone.Carvedream.global.payload.Message;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,7 +33,7 @@ public class DiaryController {
     //꿈 일기 저장
     @Operation(summary = "꿈 일기 저장", description = "오늘 기준 꿈 일기를 저장합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CreateDiaryReq.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CreateDiaryRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
     @PostMapping
@@ -44,7 +47,7 @@ public class DiaryController {
     //꿈 일기 수정
     @Operation(summary = "꿈 일기 수정", description = "꿈 일기를 수정합니다. (해몽, 이미지 제외)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "수정 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UpdateDiaryReq.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UpdateDiaryRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "수정 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
     @PatchMapping
@@ -53,6 +56,20 @@ public class DiaryController {
             @Valid @RequestBody UpdateDiaryReq updateDiaryReq
             ) {
         return ResponseEntity.ok(diaryService.updateDiary(userPrincipal, updateDiaryReq));
+    }
+
+    //꿈 일기 삭제
+    @Operation(summary = "꿈 일기 삭제", description = "꿈 일기를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<CommonDto> deleteDiary(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable(value = "diaryId") Long diaryId
+    ) {
+        return ResponseEntity.ok(diaryService.deleteDiary(userPrincipal, diaryId));
     }
 
 }

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -4,6 +4,7 @@ import com.capstone.Carvedream.domain.diary.application.DiaryService;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.response.CreateDiaryRes;
+import com.capstone.Carvedream.domain.diary.dto.response.FindDiaryRes;
 import com.capstone.Carvedream.domain.diary.dto.response.UpdateDiaryRes;
 import com.capstone.Carvedream.global.config.security.token.CurrentUser;
 import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
@@ -70,6 +71,20 @@ public class DiaryController {
             @PathVariable(value = "diaryId") Long diaryId
     ) {
         return ResponseEntity.ok(diaryService.deleteDiary(userPrincipal, diaryId));
+    }
+
+    //꿈 일기 조회(하나)
+    @Operation(summary = "꿈 일기 조회", description = "ID에 해당하는 꿈 일기를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindDiaryRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<CommonDto> findDiary (
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable(value = "diaryId") Long diaryId
+    ) {
+        return ResponseEntity.ok(diaryService.findDiary(userPrincipal, diaryId));
     }
 
 }


### PR DESCRIPTION
## ✏️ Description
API 명세서에 있는 Diary API를 생성합니다. 아직 세팅되지 않은 해몽 등 기능은 차순위로 미뤘습니다.

## To-Do List
- [x] 꿈 일기 생성
- [x] 꿈 일기 수정
- [x] 꿈 일기 삭제
- [x] id로 일기 조회
- [x] 일기 전체 조회

## 전달사항
혹시 이상한 부분 있으면 바로 연락주세요:) 확인하시고 Approve 달아주시면 감사하겠습니다.