### PR TITLE
[Feat] : 해몽, 이미지화 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,19 @@ dependencies {
 
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	implementation 'org.json:json:20210307'
+
+	implementation "com.deepl.api:deepl-java:1.5.0"   	//번역
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'com.theokanning.openai-gpt3-java:client:0.10.0'
+	implementation 'com.theokanning.openai-gpt3-java:service:0.10.0'
+
+	implementation 'com.stripe:stripe-java:22.10.0'
+	implementation 'javax.xml.bind:jaxb-api:2.3.0'
+	implementation 'sh.platform:config:2.2.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone/Carvedream/CarveDreamApplication.java
+++ b/src/main/java/com/capstone/Carvedream/CarveDreamApplication.java
@@ -1,10 +1,7 @@
 package com.capstone.Carvedream;
 
-import com.capstone.Carvedream.global.config.YamlPropertySourceFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
-
 
 @SpringBootApplication
 public class CarveDreamApplication {

--- a/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/CreateImageReq.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/dto/request/CreateImageReq.java
@@ -1,0 +1,15 @@
+package com.capstone.Carvedream.domain.diary.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "CreateImageRequest")
+public class CreateImageReq {
+
+    @Schema(description = "일기ID", example = "1")
+    private Long id;
+
+    @Schema(description = "내용", example = "캐나다의 밤하늘에서 오로라를 보는 몽환적인 꿈")
+    private String content;
+}

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -1,5 +1,6 @@
 package com.capstone.Carvedream.domain.diary.presentation;
 
+import com.capstone.Carvedream.domain.GPT.application.GPTService;
 import com.capstone.Carvedream.domain.diary.application.DiaryService;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateImageReq;
@@ -34,6 +35,7 @@ import java.io.IOException;
 public class DiaryController {
 
     private final DiaryService diaryService;
+    private final GPTService gptService;
 
     //꿈 일기 저장
     @Operation(summary = "꿈 일기 저장", description = "오늘 기준 꿈 일기를 저장합니다.")
@@ -115,7 +117,7 @@ public class DiaryController {
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Valid @RequestBody UseGptReq useGptReq
     ) {
-        return ResponseEntity.ok(diaryService.interpret(userPrincipal, useGptReq));
+        return ResponseEntity.ok(gptService.interpret(userPrincipal, useGptReq));
     }
 
     @Operation(summary = "이미지화하기", description = "문자열에 대한 이미지url 결과를 보여줍니다. (작성한 일기가 없다면 id는 0으로)")

--- a/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
+++ b/src/main/java/com/capstone/Carvedream/domain/diary/presentation/DiaryController.java
@@ -2,6 +2,7 @@ package com.capstone.Carvedream.domain.diary.presentation;
 
 import com.capstone.Carvedream.domain.diary.application.DiaryService;
 import com.capstone.Carvedream.domain.diary.dto.request.CreateDiaryReq;
+import com.capstone.Carvedream.domain.diary.dto.request.CreateImageReq;
 import com.capstone.Carvedream.domain.diary.dto.request.UpdateDiaryReq;
 import com.capstone.Carvedream.domain.diary.dto.request.UseGptReq;
 import com.capstone.Carvedream.domain.diary.dto.response.*;
@@ -10,6 +11,7 @@ import com.capstone.Carvedream.global.config.security.token.UserPrincipal;
 import com.capstone.Carvedream.global.payload.CommonDto;
 import com.capstone.Carvedream.global.payload.ErrorResponse;
 import com.capstone.Carvedream.global.payload.Message;
+import com.deepl.api.DeepLException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -121,13 +123,12 @@ public class DiaryController {
             @ApiResponse(responseCode = "200", description = "이미지화 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UseGptRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "이미지화 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PostMapping("/image/{diaryId}")
+    @PostMapping("/image")
     public ResponseEntity<CommonDto> createImage (
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @PathVariable(value = "diaryId") Long diaryId,
-            @Parameter(description = "img의 url") @RequestPart(value = "img", required = false) MultipartFile imageUrl
-    ) throws IOException {
-        return ResponseEntity.ok(diaryService.createImage(userPrincipal, diaryId, imageUrl));
+            @Valid @RequestBody CreateImageReq createImageReq
+    ) throws IOException, DeepLException, InterruptedException {
+        return ResponseEntity.ok(diaryService.createImage(userPrincipal, createImageReq));
     }
 
     // 태그 검색

--- a/src/main/java/com/capstone/Carvedream/global/config/security/DalleConfig.java
+++ b/src/main/java/com/capstone/Carvedream/global/config/security/DalleConfig.java
@@ -1,0 +1,20 @@
+package com.capstone.Carvedream.global.config.security;
+
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class DalleConfig {
+    @Value("${gpt.apiKey}")
+    private String apiKey;
+
+
+    @Bean
+    public OpenAiService getOpenAiService() {
+        return new OpenAiService(apiKey, Duration.ofSeconds(30));
+    }
+}


### PR DESCRIPTION
이미지화 api는 DeepL api를 통해 번역, Dalle api를 통해 이미지화를 구현했습니다.
해몽 api는 기존 챗봇에서 사용한 api를 사용해 해몽 데이터를 넣고 저장했습니다.

Dalle API 특성상 한글로 요청했을 때 제대로 인식하지 못해서 번역하는 과정을 거칩니다.
그래서 그만큼 응답까지 시간이 많이 드는데, 이 부분을 어떻게 보완할지 고민해야 할 것 같습니다.